### PR TITLE
Making steamlaunchermanager reusable as module

### DIFF
--- a/steamlaunchermanager.py
+++ b/steamlaunchermanager.py
@@ -3,20 +3,30 @@
 import os
 import shutil
 
-# Define paths and folders
-launchers_dir = "/home/deck/.local/share/Steam/steamapps/compatdata/Launchers"
-prefixes_root = "/home/deck/.local/share/Steam/steamapps/compatdata"
-folders_to_find = [
-    "Program Files (x86)/Ubisoft",
-    "Program Files/Rockstar Games",
-    "Program Files/Electronic Arts"
-]
+class Config:
+    launchers_dir: str
+    prefixes_root: str
+    folders_to_find: list[str]
 
-# Ensure the Launchers directory exists
-os.makedirs(launchers_dir, exist_ok=True)
+def get_default_config() -> Config:
+    config = Config()
+    # Define paths and folders
+    config.launchers_dir = "/home/deck/.local/share/Steam/steamapps/compatdata/Launchers"
+    config.prefixes_root = "/home/deck/.local/share/Steam/steamapps/compatdata"
+    config.folders_to_find = [
+        "Program Files (x86)/Ubisoft",
+        "Program Files/Rockstar Games",
+        "Program Files/Electronic Arts"
+    ]
+
+    return config
+
+def create_launchers_dir(launchers_dir):
+    # Ensure the Launchers directory exists
+    os.makedirs(launchers_dir, exist_ok=True)
 
 # Function to handle a single launcher folder in a prefix
-def process_folder(prefix_path, relative_folder):
+def process_folder(launchers_dir, prefix_path, relative_folder):
     original_folder = os.path.join(prefix_path, "pfx/drive_c", relative_folder)
     launcher_folder = os.path.join(launchers_dir, os.path.basename(relative_folder))
 
@@ -31,8 +41,19 @@ def process_folder(prefix_path, relative_folder):
         print(f"Replaced {original_folder} with symlink to {launcher_folder}")
 
 # Traverse each prefix and process the folders
-for prefix in os.listdir(prefixes_root):
-    prefix_path = os.path.join(prefixes_root, prefix)
-    if os.path.isdir(prefix_path):
-        for folder in folders_to_find:
-            process_folder(prefix_path, folder)
+def process_folders(config: Config):
+    for prefix in os.listdir(config.prefixes_root):
+        prefix_path = os.path.join(config.prefixes_root, prefix)
+        if os.path.isdir(prefix_path):
+            for folder in config.folders_to_find:
+                process_folder(config.launchers_dir, prefix_path, folder)
+
+# main logic
+def main(config: Config):
+    create_launchers_dir(config.launchers_dir)
+
+    process_folders(config)
+
+if __name__ == "__main__":
+    config = get_default_config()
+    main(config)


### PR DESCRIPTION
### Making steamlaunchermanager.py reusable, so it can be used eg. as a DockyLoader plugin.

I was thinking about making a DockyLoader plugin out of it (or maybe just a gui), but to avoid copy-pasting and changing everything every update, it would be nice to have the base usable as a module (could be clonned to py_modules).
This way it's only necessary to update it on major changes.

This is just a POC made at 4am, so feel free to make or suggest any changes or just ditch the code.
Also I feel like I overcomplicated Config a bit. I'm not too used to the "python way" of doing things.